### PR TITLE
Add support for injected or global Property value capture

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -1,3 +1,8 @@
+resources:
+  containers:
+  - container: nv-bionic-wasm
+    image: nventive/wasm-build:1.4.1
+
 jobs:
 - job: Windows
 
@@ -53,6 +58,7 @@ jobs:
       ArtifactType: Container
 
 - job: Linux
+  container: nv-bionic-wasm
 
   variables:
     NUGET_PACKAGES: $(Agent.WorkFolder)\.nuget

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -60,9 +60,6 @@ jobs:
 - job: Linux
   container: nv-bionic-wasm
 
-  variables:
-    NUGET_PACKAGES: $(Agent.WorkFolder)\.nuget
-
   pool:
     vmImage: 'ubuntu-16.04'
 

--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -3,7 +3,8 @@
 ## Next version
 
 ### Features
-- 
+- Introduction of the `UnoSourceGeneratorAdditionalProperty` item group allows for the propagation of those properties to the generators. (#112)
+
 ### Breaking changes
 - 
 ### Bug fixes

--- a/readme.md
+++ b/readme.md
@@ -203,9 +203,34 @@ You can write to build output using the following code:
     }
 ```
 
+## Available Properties
+
+The source generation task provides set of properties that can alter its behavior based on your project.
+
+### UnoSourceGeneratorAdditionalProperty
+
+The `UnoSourceGeneratorAdditionalProperty` item group provides the ability for a project to enable the
+propagation of specific properties to the generators. This may be required if properties are 
+[injected dynamically](https://github.com/Microsoft/VSProjectSystem/blob/master/doc/extensibility/IProjectGlobalPropertiesProvider.md#iprojectglobalpropertiesprovider),
+or provided as global variables.
+
+A good example of this is the `JavaSdkDirectory` that is generally injected as a global parameter through
+the msbuild command line.
+
+In such as case, add the following in your project file:
+
+```xml
+<ItemGroup>
+    <UnoSourceGeneratorAdditionalProperty Include="JavaSdkDirectory" />
+</ItemGroup>
+```
+
+In this case, the `JavaSdkDirectory` value will be captured in the original build environment, and provided
+to the generators' build environment.
+
 ## Troubleshooting
 
-## Error: `Failed to analyze project file ..., the targets ... failed to execute.`
+### Error: `Failed to analyze project file ..., the targets ... failed to execute.`
 
 This is issue is caused by a [open Roslyn issue](https://github.com/nventive/Uno.SourceGeneration/issues/2)
 for which all projects of the solution must have all the possible "head" projects configuration.

--- a/src/Uno.SampleCoreApp/Uno.SampleCoreApp.csproj
+++ b/src/Uno.SampleCoreApp/Uno.SampleCoreApp.csproj
@@ -24,5 +24,17 @@
   <ItemGroup>
 	<SourceGenerator Include="..\Uno.SampleGenerators\bin\$(Configuration)\Uno.SampleGenerators.dll" />
   </ItemGroup>
+  
+  <PropertyGroup Condition="'$(BuildingInsideUnoSourceGenerator)'==''">
+    <!--
+    Conditionally include this property group so that while in the source generator build
+    context, the value is provided through the capture of the original build context.
+    -->
+    <MyTestProperty>42</MyTestProperty>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <UnoSourceGeneratorAdditionalProperty Include="MyTestProperty" />
+  </ItemGroup>
 
 </Project>

--- a/src/Uno.SampleGenerators/AdditionalPropertiesGenerator.cs
+++ b/src/Uno.SampleGenerators/AdditionalPropertiesGenerator.cs
@@ -1,0 +1,41 @@
+﻿// ******************************************************************
+// Copyright � 2015-2018 nventive inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ******************************************************************
+using Uno.SourceGeneration;
+
+namespace Uno.SampleGenerators
+{
+	[GenerateAfter("Uno.SampleGenerators.MyCustomSourceGenerator")]
+	public class AdditionalPropertiesGenerator : GeneratorBaseClass
+	{
+		public override void Execute(SourceGeneratorContext context)
+		{
+			var project = context.GetProjectInstance();
+
+			context.AddCompilationUnit(
+				"Test2",
+				$@"
+namespace AdditionalPropertiesGeneratorTest {{
+	public static class TestType
+	{{
+		// Project: {project?.FullPath}
+		// reusing the compiled code form other generator
+		public const int Project = {project.GetProperty("MyTestProperty").EvaluatedValue};
+	}}
+}}");
+		}
+	}
+}

--- a/src/Uno.SampleGenerators/Uno.SampleGenerators.csproj
+++ b/src/Uno.SampleGenerators/Uno.SampleGenerators.csproj
@@ -72,6 +72,7 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AdditionalPropertiesGenerator.cs" />
     <Compile Include="AnotherCustomSourceGenerator.cs" />
     <Compile Include="GeneratorBaseClass.cs" />
     <Compile Include="MyCustomSourceGenerator.cs" />

--- a/src/Uno.SampleProject.UWP/Uno.SampleProject.UWP.csproj
+++ b/src/Uno.SampleProject.UWP/Uno.SampleProject.UWP.csproj
@@ -127,6 +127,19 @@
   <ItemGroup>
     <SourceGenerator Include="..\Uno.SampleGenerators\bin\$(Configuration)\Uno.SampleGenerators.dll" />
   </ItemGroup>
+  
+  <PropertyGroup Condition="'$(BuildingInsideUnoSourceGenerator)'==''">
+    <!--
+    Conditionally include this property group so that while in the source generator build
+    context, the value is provided through the capture of the original build context.
+    -->
+    <MyTestProperty>42</MyTestProperty>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <UnoSourceGeneratorAdditionalProperty Include="MyTestProperty" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Uno.SampleDependency\Uno.SampleDependency.csproj">
       <Project>{D02FBC83-F9DD-4710-AEBF-0BA2F8AE85B2}</Project>

--- a/src/Uno.SampleProject/Uno.SampleProject.csproj
+++ b/src/Uno.SampleProject/Uno.SampleProject.csproj
@@ -23,6 +23,18 @@
   <ItemGroup>
     <SourceGenerator Include="..\Uno.SampleGenerators\bin\$(Configuration)\Uno.SampleGenerators.dll" />
   </ItemGroup>
+  
+  <PropertyGroup Condition="'$(BuildingInsideUnoSourceGenerator)'==''">
+    <!--
+    Conditionally include this property group so that while in the source generator build
+    context, the value is provided through the capture of the original build context.
+    -->
+    <MyTestProperty>42</MyTestProperty>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <UnoSourceGeneratorAdditionalProperty Include="MyTestProperty" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="System.ValueTuple">

--- a/src/Uno.SampleProject/Uno.SampleProject.csproj
+++ b/src/Uno.SampleProject/Uno.SampleProject.csproj
@@ -34,6 +34,7 @@
 
   <ItemGroup>
     <UnoSourceGeneratorAdditionalProperty Include="MyTestProperty" />
+    <UnoSourceGeneratorAdditionalProperty Include="__UNKNOWN_UNO_PROPERTY__" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Uno.SourceGeneration.Engine.Shared/ProjectLoader.cs
+++ b/src/Uno.SourceGeneration.Engine.Shared/ProjectLoader.cs
@@ -68,6 +68,12 @@ namespace Uno.SourceGeneration.Host
 				}
 			}
 
+			// Merge additional properties
+			foreach(var prop in environment.AdditionalProperties)
+			{
+				globalProperties[prop.Key] = prop.Value;
+			}
+
 			if (_log.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
 			{
 				_log.LogDebug($"Loading project file [{environment.ProjectFile}]");

--- a/src/Uno.SourceGeneration.Protocol/GenerationClient/BuildEnvironment.cs
+++ b/src/Uno.SourceGeneration.Protocol/GenerationClient/BuildEnvironment.cs
@@ -51,5 +51,8 @@ namespace Uno.SourceGeneratorTasks
 
 		[DataMember]
 		public string[] ReferencePath { get; set; }
+
+		[DataMember]
+		public Dictionary<string, string> AdditionalProperties { get; set; }
 	}
 }

--- a/src/Uno.SourceGeneratorTasks.Dev15.0/Content/Uno.SourceGenerationTasks.targets
+++ b/src/Uno.SourceGeneratorTasks.Dev15.0/Content/Uno.SourceGenerationTasks.targets
@@ -109,6 +109,11 @@
                                              Condition="'%(Extension)' == '.dll'" />
 	</ItemGroup>
 
+	<ItemGroup>
+	  <!-- Capture the values of the additional property values -->
+	  <_UnoSourceGeneratorAdditionalProperty Include="@(UnoSourceGeneratorAdditionalProperty)" Value="$(%(Identity))" />
+	</ItemGroup>
+
 	<PropertyGroup Condition="'$(_UnoSourceGeneratorProjectType)'=='ios' or '$(_UnoSourceGeneratorProjectType)'=='mac'">
 	  <!-- 
 			Workaround until we can determine where the logic behind `TargetFrameworkRootPathSearchPathsOSX` 
@@ -134,6 +139,7 @@
 							  BinLogOutputPath="$(UnoSourceGeneratorBinLogOutputPath)"
 							  BinLogEnabled="$(UnoSourceGeneratorUnsecureBinLogEnabled)"
 							  ReferencePath="@(_AssembliesForReferenceCopyLocalPaths)"
+						      AdditionalProperties="@(_UnoSourceGeneratorAdditionalProperty)"
 							  Condition="$(_hasSourceGenerators)">
 	  <Output TaskParameter="GenereratedFiles" ItemName="UnoGeneratedFiles" />
 	</SourceGenerationTask_v0>

--- a/src/Uno.SourceGeneratorTasks.Dev15.0/Tasks/SourceGenerationTask.cs
+++ b/src/Uno.SourceGeneratorTasks.Dev15.0/Tasks/SourceGenerationTask.cs
@@ -88,6 +88,9 @@ namespace Uno.SourceGeneratorTasks
 		[Required]
 		public Microsoft.Build.Framework.ITaskItem[] ReferencePath { get; set; }
 
+		[Required]
+		public Microsoft.Build.Framework.ITaskItem[] AdditionalProperties { get; set; }
+
 		[Output]
 		public string[] GenereratedFiles { get; set; }
 
@@ -436,7 +439,9 @@ namespace Uno.SourceGeneratorTasks
 				MSBuildBinPath = Path.GetDirectoryName(new Uri(typeof(Microsoft.Build.Logging.ConsoleLogger).Assembly.CodeBase).LocalPath),
 				AdditionalAssemblies = AdditionalAssemblies,
 				SourceGenerators = SourceGenerators,
-				ReferencePath = ReferencePath.Select(r => r.ItemSpec).ToArray()
+				ReferencePath = ReferencePath.Select(r => r.ItemSpec).ToArray(),
+				AdditionalProperties = AdditionalProperties
+					.ToDictionary(v => v.ItemSpec, v => v.GetMetadata("Value")),
 			};
 
 		private string EnsureRootedPath(string projectFile, string targetPath) =>


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Feature

## What is the current behavior?
Dynamic or global properties provided to msbuild are not available in the generators' build context, such as `JavaSdkDirectory`.

## What is the new behavior?
The introduction of the `UnoSourceGeneratorAdditionalProperty` item group allows for the propagation of those properties to the generators.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno.SourceGeneration/tree/master/doc/.feature-template.md). (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno.SourceGeneration/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->