### PR TITLE
fix: Failsafe on "Found invalid data while decoding" binlog replay from controller

### DIFF
--- a/src/Uno.SourceGeneratorTasks.Dev15.0/Tasks/SourceGenerationTask.cs
+++ b/src/Uno.SourceGeneratorTasks.Dev15.0/Tasks/SourceGenerationTask.cs
@@ -217,7 +217,7 @@ namespace Uno.SourceGeneratorTasks
 
 					responseTask.Wait(_sharedCompileCts.Token);
 
-					BinaryLoggerReplayHelper.Replay(BuildEngine, binlogFile);
+					BinaryLoggerReplayHelper.Replay(BuildEngine, binlogFile, Log);
 
 					if (responseTask.Result.Type == GenerationResponse.ResponseType.Completed)
 					{
@@ -340,7 +340,7 @@ namespace Uno.SourceGeneratorTasks
 						process.WaitForExit();
 					}
 
-					BinaryLoggerReplayHelper.Replay(BuildEngine, binlogFile);
+					BinaryLoggerReplayHelper.Replay(BuildEngine, binlogFile, Log);
 
 					if (process.ExitCode == 0)
 					{


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
The generation may fail with :

```
System.IO.InvalidDataException: Found invalid data while decoding.
   at System.IO.Compression.InflaterZlib.Inflate(FlushCode flushCode)
   at System.IO.Compression.InflaterZlib.ReadInflateOutput(Byte[] outputBuffer, Int32 offset, Int32 length, FlushCode flushCode, Int32& bytesRead)
   at System.IO.Compression.InflaterZlib.Inflate(Byte[] bytes, Int32 offset, Int32 length)
   at System.IO.Compression.DeflateStream.Read(Byte[] array, Int32 offset, Int32 count)
   at System.IO.Compression.GZipStream.Read(Byte[] array, Int32 offset, Int32 count)
   at System.IO.Stream.ReadByte()
   at System.IO.BinaryReader.ReadByte()
   at Microsoft.Build.Logging.BuildEventArgsReader.Read7BitEncodedInt(BinaryReader reader)
   at Microsoft.Build.Logging.BuildEventArgsReader.Read()
   at Microsoft.Build.Logging.BinaryLogReplayEventSource.Replay(String sourceFilePath, CancellationToken cancellationToken)
   at Uno.SourceGeneration.Helpers.BinaryLoggerReplayHelper.Replay(IBuildEngine engine, String filePath) in D:\a\1\s\src\Uno.SourceGeneration.Protocol\Helpers\BinaryLoggerReplayHelper.cs:line 24
   at Uno.SourceGeneratorTasks.SourceGenerationTask_vea955a299f97c1cdda9b6df269c524e416c7cff6.GenerateWithHostController() in D:\a\1\s\src\Uno.SourceGeneratorTasks.Dev15.0\Tasks\SourceGenerationTask.cs:line 218
   at Uno.SourceGeneratorTasks.SourceGenerationTask_vea955a299f97c1cdda9b6df269c524e416c7cff6.Execute() in D:\a\1\s\src\Uno.SourceGeneratorTasks.Dev15.0\Tasks\SourceGenerationTask.cs:line 121
```


## What is the new behavior?

For some yet unknown reason, the stream may be invalid, while the file seems to be generated properly. This change only skips the binlog replay if an exception happens during the replay.