### PR TITLE
fix: Bump System.Collections.Immutable to 1.7.1 for VS 19.10 Pre 3 compat

### DIFF
--- a/src/Uno.SourceGeneration.Host/Uno.SourceGeneration.Host.csproj
+++ b/src/Uno.SourceGeneration.Host/Uno.SourceGeneration.Host.csproj
@@ -46,7 +46,10 @@
 	<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common">
 	  <Version>3.6.0</Version>
 	</PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.6.0" />
+	<PackageReference Include="System.Collections.Immutable">
+	  <Version>1.7.1</Version>
+	</PackageReference>
+	<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.6.0" />
     <PackageReference Include="Microsoft.VisualStudio.RemoteControl">
 	  <Version>14.0.262-masterA5CACE98</Version>
 	</PackageReference>
@@ -114,6 +117,9 @@
 	</PackageReference>
 	<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common">
 	  <Version>3.6.0</Version>
+	</PackageReference>
+	<PackageReference Include="System.Collections.Immutable">
+	  <Version>1.7.1</Version>
 	</PackageReference>
 	<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.6.0" />
 	<PackageReference Include="Microsoft.DiaSymReader" Version="1.3.0" />


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno/issues/5996
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type
What kind of change does this PR introduce?
bugfix

## What is the new behavior?
VS 16.10 msbuild binaries are referencing a newer version of the `System.Collection.Immutable` assembly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno.SourceGeneration/tree/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno.SourceGeneration/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->