### PR TITLE
fix: Enable LatestMajor RollForward for source generation host

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -92,68 +92,6 @@ jobs:
       ArtifactName: unosourcegenerator-drop
       ArtifactType: Container
 
-- job: Windows_VS2017
-  dependsOn:
-  - Build_Packages
-
-  variables:
-    SAMPLES_BUILD: true
-    NUGET_PACKAGES: $(Pipeline.Workspace)\.nuget\packages
-    RestoreLockedMode: false # Until https://github.com/NuGet/Home/issues/8645
-
-  pool:
-    vmImage: 'vs2017-win2016'
-
-  steps:
-
-  - task: CacheBeta@0
-    inputs:
-      key: nuget | **/packages.lock.json
-      path: $(NUGET_PACKAGES)
-    displayName: Cache NuGet packages
-     
-  - task: GitVersion@5
-    inputs:
-      configFilePath: '$(build.sourcesdirectory)\gitversion.yml'
-
-  - task: DownloadBuildArtifacts@0
-    inputs:
-      ArtifactName: unosourcegenerator-drop
-      downloadPath: '$(System.ArtifactsDirectory)'
-
-  - task: CopyFiles@2
-    inputs:
-        sourceFolder: '$(System.ArtifactsDirectory)\unosourcegenerator-drop\build'
-        targetFolder: $(build.sourcesdirectory)\src\PackageCache
-      
-  - task: MSBuild@1
-    inputs:
-      solution: '$(build.sourcesdirectory)/src/Uno.SourceGenerator.Samples.Windows.sln'
-      msbuildArguments: /m /r /p:configuration=Release /p:SOURCEGEN_VERSION=$(GITVERSION.SemVer) /bl:$(build.artifactstagingdirectory)/binlog/windows-sample-build.binlog
-
-  # Update .NET core after msbuild, otherwise this error happens:
-  #
-  #    Error : The current .NET SDK does not support targeting .NET Standard 2.0.  Either target .NET Standard 1.6 or lower, or use a version of the .NET SDK that supports .NET Standard 2.0.
-  #
-  - task: DotNetCoreInstaller@2
-    inputs:
-      version: '3.1.x'
-      installationPath: $(Agent.ToolsDirectory)/dotnet
-
-  - task: DotNetCoreCLI@2
-    displayName: Validate .NET Core 3.1.x CLI build
-    inputs:
-      command: build
-      arguments: "--configuration Release -p:SOURCEGEN_VERSION=$(GITVERSION.SemVer)  /bl:$(build.artifactstagingdirectory)/binlog/windows-sample-build-netcore.binlog"
-      workingDirectory: $(build.sourcesdirectory)/src/Uno.SampleCoreApp
-            
-  - task: PublishBuildArtifacts@1
-    condition: always()
-    inputs:
-      PathtoPublish: $(build.artifactstagingdirectory)/binlog
-      ArtifactName: unosourcegenerator-binlog
-      ArtifactType: Container
-
 - job: Windows_VS2019
   dependsOn:
   - Build_Packages
@@ -186,9 +124,18 @@ jobs:
       path: $(NUGET_PACKAGES)
     displayName: Cache NuGet packages
      
-  - task: GitVersion@5
+  - task: gitversion/setup@0
+    retryCountOnTaskFailure: 3
     inputs:
-      configFilePath: '$(build.sourcesdirectory)\gitversion.yml'
+      versionSpec: '5.6.8'
+
+  - task: gitversion/execute@0
+    retryCountOnTaskFailure: 3
+    inputs:
+      updateAssemblyInfo: 'False'
+      useConfigFile: true
+      configFilePath: gitversion.yml
+    displayName: Use GitVersion
 
   - task: DownloadBuildArtifacts@0
     inputs:
@@ -274,9 +221,18 @@ jobs:
       version: 3.1.x
       installationPath: $(Agent.ToolsDirectory)/dotnet
 
-  - task: GitVersion@5
+  - task: gitversion/setup@0
+    retryCountOnTaskFailure: 3
     inputs:
-      configFilePath: '$(build.sourcesdirectory)/gitversion.yml'
+      versionSpec: '5.6.8'
+
+  - task: gitversion/execute@0
+    retryCountOnTaskFailure: 3
+    inputs:
+      updateAssemblyInfo: 'False'
+      useConfigFile: true
+      configFilePath: gitversion.yml
+    displayName: Use GitVersion
 
   - task: DownloadBuildArtifacts@0
     inputs:
@@ -385,9 +341,18 @@ jobs:
       version: 3.1.x
       installationPath: $(Agent.ToolsDirectory)/dotnet
      
-  - task: GitVersion@5
+  - task: gitversion/setup@0
+    retryCountOnTaskFailure: 3
     inputs:
-      configFilePath: '$(build.sourcesdirectory)/gitversion.yml'
+      versionSpec: '5.6.8'
+
+  - task: gitversion/execute@0
+    retryCountOnTaskFailure: 3
+    inputs:
+      updateAssemblyInfo: 'False'
+      useConfigFile: true
+      configFilePath: gitversion.yml
+    displayName: Use GitVersion
 
   - task: CacheBeta@0
     inputs:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -17,9 +17,18 @@ jobs:
       path: $(NUGET_PACKAGES)
     displayName: Cache NuGet packages
      
-  - task: GitVersion@5
+  - task: gitversion/setup@0
+    retryCountOnTaskFailure: 3
     inputs:
-      configFilePath: '$(build.sourcesdirectory)\gitversion.yml'
+      versionSpec: '5.6.8'
+
+  - task: gitversion/execute@0
+    retryCountOnTaskFailure: 3
+    inputs:
+      updateAssemblyInfo: 'False'
+      useConfigFile: true
+      configFilePath: gitversion.yml
+    displayName: Use GitVersion
 
   - task: NuGetToolInstaller@0
     inputs:

--- a/src/Uno.FSSampleProject/packages.lock.json
+++ b/src/Uno.FSSampleProject/packages.lock.json
@@ -2,6 +2,12 @@
   "version": 1,
   "dependencies": {
     ".NETStandard,Version=v2.0": {
+      "FSharp.Core": {
+        "type": "Direct",
+        "requested": "[6.0.3-beta.*, )",
+        "resolved": "6.0.3",
+        "contentHash": "ywxwMhsA1nG2hsRSMl3IzYvdugrSoFg/ZY99cuBqV0SX0yp8ubD6Hee8Bh3YwaF2Ucyq/Jz8lZ0MY5VjxgogbA=="
+      },
       "NETStandard.Library": {
         "type": "Direct",
         "requested": "[2.0.3, )",

--- a/src/Uno.SourceGeneration.Host/Uno.SourceGeneration.Host.csproj
+++ b/src/Uno.SourceGeneration.Host/Uno.SourceGeneration.Host.csproj
@@ -9,6 +9,7 @@
 	<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 	<LangVersion>7.2</LangVersion>
 	<AppConfig>$(MSBuildThisFileDirectory)app.$(TargetFramework).config</AppConfig>
+	<RollForward>LatestMajor</RollForward>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net472'">


### PR DESCRIPTION
Enables the generation host to follow for preview releases installed in the environment