### PR TITLE
fix: Select the net6 (latest) binaries if a newer runtime is used

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -106,6 +106,10 @@ jobs:
 
   strategy:
     matrix:
+      NetCore_7_0_100_Preview_Override:
+        NETCORE_VERSION: 7.0.100-preview.6.22352.1
+        TARGETFRAMEWORKOVERRIDE: net7.0
+        NETCORE_PREVIEW: True
       NetCore_7_0_100_Preview:
         NETCORE_VERSION: 7.0.100-preview.6.22352.1
         NETCORE_PREVIEW: True
@@ -172,7 +176,7 @@ jobs:
     displayName: Validate .NET Core $(NETCORE_VERSION) CLI build
     inputs:
       command: build
-      arguments: "--configuration Release -p:SOURCEGEN_VERSION=$(GITVERSION.SemVer)  /bl:$(build.artifactstagingdirectory)/binlog/windows-sample-build-netcore.binlog"
+      arguments: "--configuration Release -p:SOURCEGEN_VERSION=$(GITVERSION.SemVer) /bl:$(build.artifactstagingdirectory)/binlog/windows-sample-build-netcore.binlog"
       workingDirectory: $(build.sourcesdirectory)/src/Uno.SampleCoreApp
             
   - task: PublishBuildArtifacts@1

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -106,9 +106,18 @@ jobs:
 
   strategy:
     matrix:
-      NetCore_6_0:
-        NETCORE_VERSION: 6.0.100-preview.6.21355.2
+      NetCore_7_0_100_Preveiew:
+        NETCORE_VERSION: 7.0.100-preview.6.22352.1
         NETCORE_PREVIEW: True
+      NetCore_6_0_302:
+        NETCORE_VERSION: 6.0.302
+        NETCORE_PREVIEW: False
+      NetCore_6_0_300:
+        NETCORE_VERSION: 6.0.300
+        NETCORE_PREVIEW: False
+      NetCore_6_0_100:
+        NETCORE_VERSION: 6.0.100
+        NETCORE_PREVIEW: False
       NetCore_5_0:
         NETCORE_VERSION: 5.0.x
         NETCORE_PREVIEW: False
@@ -180,9 +189,18 @@ jobs:
 
   strategy:
     matrix:
-      NetCore_6_0:
-        NETCORE_VERSION: 6.0.100-preview.6.21355.2
+      NetCore_7_0_100_Preveiew:
+        NETCORE_VERSION: 7.0.100-preview.6.22352.1
         NETCORE_PREVIEW: True
+      NetCore_6_0_302:
+        NETCORE_VERSION: 6.0.302
+        NETCORE_PREVIEW: False
+      NetCore_6_0_300:
+        NETCORE_VERSION: 6.0.300
+        NETCORE_PREVIEW: False
+      NetCore_6_0_100:
+        NETCORE_VERSION: 6.0.100
+        NETCORE_PREVIEW: False
       NetCore_5_0:
         NETCORE_VERSION: 5.0.x
         NETCORE_PREVIEW: False
@@ -280,12 +298,21 @@ jobs:
 
   strategy:
     matrix:
-      # Disable in Preview two for https://github.com/dotnet/runtime/issues/49610
-      # Xamarin_6_12_0_NET_6_0:
-      #   XamarinVersion: 6_12_0
-      #   VM_Image: 'macOS-10.15'
-      #   NETCORE_VERSION: 6.0.100-preview.6.21355.2
-      #   NETCORE_PREVIEW: True
+      Xamarin_6_12_0_NET_7_0_100:
+         XamarinVersion: 7.0.100-preview.6.22352.1
+         VM_Image: 'macOS-12'
+         NETCORE_VERSION: 7.0.100
+         NETCORE_PREVIEW: True
+      Xamarin_6_12_0_NET_6_0_302:
+         XamarinVersion: 6_12_0
+         VM_Image: 'macOS-10.15'
+         NETCORE_VERSION: 6.0.302
+         NETCORE_PREVIEW: False
+      Xamarin_6_12_0_NET_6_0_100:
+         XamarinVersion: 6_12_0
+         VM_Image: 'macOS-10.15'
+         NETCORE_VERSION: 6.0.100
+         NETCORE_PREVIEW: False
       Xamarin_6_6_0_NetCore_5_0:
         XamarinVersion: 6_6_0
         VM_Image: 'macOS-10.15'

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -106,7 +106,7 @@ jobs:
 
   strategy:
     matrix:
-      NetCore_7_0_100_Preveiew:
+      NetCore_7_0_100_Preview:
         NETCORE_VERSION: 7.0.100-preview.6.22352.1
         NETCORE_PREVIEW: True
       NetCore_6_0_302:
@@ -189,7 +189,7 @@ jobs:
 
   strategy:
     matrix:
-      NetCore_7_0_100_Preveiew:
+      NetCore_7_0_100_Preview:
         NETCORE_VERSION: 7.0.100-preview.6.22352.1
         NETCORE_PREVIEW: True
       NetCore_6_0_302:
@@ -299,9 +299,9 @@ jobs:
   strategy:
     matrix:
       Xamarin_6_12_0_NET_7_0_100:
-         XamarinVersion: 7.0.100-preview.6.22352.1
+         XamarinVersion: 6_12_17
          VM_Image: 'macOS-12'
-         NETCORE_VERSION: 7.0.100
+         NETCORE_VERSION: 7.0.100-preview.6.22352.1
          NETCORE_PREVIEW: True
       Xamarin_6_12_0_NET_6_0_302:
          XamarinVersion: 6_12_0

--- a/src/Uno.SampleCoreApp/Uno.SampleCoreApp.csproj
+++ b/src/Uno.SampleCoreApp/Uno.SampleCoreApp.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework Condition="'$(TARGETFRAMEWORKOVERRIDE)'!=''">$(TARGETFRAMEWORKOVERRIDE)</TargetFramework>
   </PropertyGroup>
 
   <Import Project="..\SolutionBuild.targets" />


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno/issues/9207

## PR Type
What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

When using a newer (e.g. net7) botnet runtime the task uses this (hardcoded) version to find the host binary (`Uno.SourceGeneration.Host.dll`) to execute.

https://github.com/unoplatform/Uno.SourceGeneration/blob/d859a37defd43065b215a0d2dd3f68f6821e5064/src/Uno.SourceGeneratorTasks.Dev15.0/Tasks/SourceGenerationTask.cs#L384-L387


## What is the new behavior?

Assume that newer botnet versions can use the latest, existing binaries (since `<RollForward>LatestMajor</RollForward>` is enabled).

IOW if something newer is detected (e.g. `net7`) then fallback to use `net6` binaries.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno.SourceGeneration/tree/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno.SourceGeneration/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information

The original issue was filed inside the `uno` repository https://github.com/unoplatform/uno/issues/9207 based on a discussion, https://github.com/unoplatform/uno/discussions/9205, that provides a test case.

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->